### PR TITLE
fix(web): bump vite to ^6.4.2 to patch WS fetchModule arbitrary file read

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
         "svelte": "^5.55.1",
         "svelte-check": "^4.0.0",
         "typescript": "^5.0.0",
-        "vite": "^6.0.0"
+        "vite": "^6.4.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "svelte": "^5.55.1",
     "svelte-check": "^4.0.0",
     "typescript": "^5.0.0",
-    "vite": "^6.0.0"
+    "vite": "^6.4.2"
   },
   "overrides": {
     "rollup": "^4.59.0",


### PR DESCRIPTION
## Summary
- Bumps `vite` to `^6.4.2` in `web/package.json` to address Dependabot alert #25 (arbitrary file read via dev server WebSocket `fetchModule` / `vite:invoke`).
- Affected range: `>=6.0.0, <=6.4.1`. Patched in `6.4.2`.