### PR TITLE
fix(ci): use uvx for twine check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,7 @@ jobs:
         run: uv build
 
       - name: Check build artifacts
-        run: |
-          uv pip install twine
-          uv run twine check dist/*
+        run: uvx twine check dist/*
 
   web-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the build-check job failure in CI by using uvx to run twine check in an isolated environment.