### PR TITLE
fix(web): remove beta prefix from hero badge

### DIFF
--- a/web/src/lib/components/Hero.svelte
+++ b/web/src/lib/components/Hero.svelte
@@ -4,7 +4,7 @@
 <section class="hero">
   <div class="container hero-inner">
     <div class="hero-badge">
-      <span class="badge">Beta v0.1.0b3</span>
+      <span class="badge">v0.1.0</span>
     </div>
 
     <h1 class="hero-title">


### PR DESCRIPTION
Fixed a missed version update in the hero component that was showing 'Beta v0.1.0b3' on the live website.