### PR TITLE
fix(ci): add pypi environment for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write  # Mandatory for trusted publishing
       contents: read


### PR DESCRIPTION
Adds the 'pypi' environment to the release workflow to support PyPI's trusted publishing requirement.