### PR TITLE
chore: add github funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: MaskedSyntax


### PR DESCRIPTION
Adds .github/FUNDING.yml to enable the Sponsor button on the repository.